### PR TITLE
Replace old “high” and “low” keywords with current “more” and “less”

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can also include `prefersContrast()` from a CDN on your page, such as [jsDel
 
 ```js
 var contrastPreference = window.magica11y.prefersContrast.default();
-var useHighContrastColorScheme = (contrastPreference === window.magica11y.prefersContrast.contrastPreferences.HIGH);
+var useHighContrastColorScheme = (contrastPreference === window.magica11y.prefersContrast.contrastPreferences.MORE);
 ```
 
 … or as a CommonJS module…
@@ -78,7 +78,7 @@ var useHighContrastColorScheme = (contrastPreference === window.magica11y.prefer
 ```js
 const prefersContrast = require('@magica11y/prefers-contrast');
 const contrastPreference = prefersContrast.default();
-const useHighContrastColorScheme = (contrastPreference === prefersContrast.contrastPreferences.HIGH);
+const useHighContrastColorScheme = (contrastPreference === prefersContrast.contrastPreferences.MORE);
 ```
 
 … or as an ES module…
@@ -87,16 +87,16 @@ const useHighContrastColorScheme = (contrastPreference === prefersContrast.contr
 import prefersContrast, { contrastPreferences } from 'magica11y/prefersContrast';
 
 const contrastPreference = prefersContrast();
-const useHighContrastColorScheme = (contrastPreference === contrastPreferences.HIGH);
+const useHighContrastColorScheme = (contrastPreference === contrastPreferences.MORE);
 ```
 
 The `contrastPreferences` object contains all the possible values supported by the `'prefers-contrast'` media query…
 
 * `contrastPreferences.NO_PREFERENCE` (spec: [`'no-preference'`](https://drafts.csswg.org/mediaqueries-5/#valdef-media-prefers-contrast-no-preference))
   > Indicates that the user has made no preference known to the system.
-* `contrastPreferences.HIGH` (spec: [`'high'`](https://drafts.csswg.org/mediaqueries-5/#valdef-media-prefers-contrast-high))
+* `contrastPreferences.MORE` (spec: [`'more'`](https://drafts.csswg.org/mediaqueries-5/#valdef-media-prefers-contrast-more))
   > Indicates that user has notified the system that they prefer an interface that has a higher level of contrast.
-* `contrastPreferences.LOW` (spec: [`'low'`](https://drafts.csswg.org/mediaqueries-5/#valdef-media-prefers-contrast-low))
+* `contrastPreferences.LESS` (spec: [`'less'`](https://drafts.csswg.org/mediaqueries-5/#valdef-media-prefers-contrast-less))
   > Indicates that user has notified the system that they prefer an interface that has a lower level of contrast.
 * `null`
   > The user’s preference could not be determined.

--- a/src/contrastPreferences.js
+++ b/src/contrastPreferences.js
@@ -2,12 +2,12 @@
 
 const contrastPreferences: {|
   NO_PREFERENCE: string,
-  HIGH: string,
-  LOW: string,
+  MORE: string,
+  LESS: string,
 |} = Object.freeze({
   NO_PREFERENCE: 'no-preference',
-  HIGH: 'high',
-  LOW: 'low',
+  MORE: 'more',
+  LESS: 'less',
 });
 
 export type ContrastPreference = $Values<typeof contrastPreferences>;

--- a/src/prefersContrast.js
+++ b/src/prefersContrast.js
@@ -6,15 +6,15 @@ import contrastPreferences, { type ContrastPreference } from './contrastPreferen
 
 const contrastPreferenceValues: Array<ContrastPreference> = [
   contrastPreferences.NO_PREFERENCE,
-  contrastPreferences.HIGH,
-  contrastPreferences.LOW,
+  contrastPreferences.MORE,
+  contrastPreferences.LESS,
 ];
 
 /**
  * Detects user’s preferences for contrast
  * using CSS3 Media Queries level 5 specification for `'prefers-contrast'`.
  *
- * @returns Either 'no-preference', 'high', 'low' or `null`
+ * @returns Either 'no-preference', 'more', 'less' or `null`
  * @see https://drafts.csswg.org/mediaqueries-5/#prefers-contrast
  */
 const prefersContrast = (): ?ContrastPreference => {

--- a/test/prefersContrast.test.js
+++ b/test/prefersContrast.test.js
@@ -17,12 +17,12 @@ describe('prefersContrast()', () => {
         expectedOutput: 'no-preference',
       },
       {
-        testInput: contrastPreferences.HIGH,
-        expectedOutput: 'high',
+        testInput: contrastPreferences.MORE,
+        expectedOutput: 'more',
       },
       {
-        testInput: contrastPreferences.LOW,
-        expectedOutput: 'low',
+        testInput: contrastPreferences.LESS,
+        expectedOutput: 'less',
       },
     ];
 


### PR DESCRIPTION
This change replaces instances of “high” with “more”, “low” with “less”, and also updates related variable names and documentation. This follows the current [Media Queries Level 5](https://drafts.csswg.org/mediaqueries-5/#prefers-contrast) draft.